### PR TITLE
feat: Competition API Integration — Fetch & Display Competitions and Prizes

### DIFF
--- a/src/api/competitions.ts
+++ b/src/api/competitions.ts
@@ -2,26 +2,41 @@ import api from ".";
 
 export interface ApiCompetition {
   id: number;
+  event_id: number;
+  chapter_id: number;
   name: string;
-  short_name: string;
-  description: string;
   overview: string;
-  image: string;
-  link: string;
-  rulebook: string | null;
-  trophies_description: string;
-  rules_description: string;
+  type: "individual" | "team";
+  max_team_members: number;
+  created_at: string;
+  updated_at: string;
+  prizes: ApiPrize[];
 }
 
 export interface ApiPrize {
   id: number;
-  place: string;
-  amount: string;
+  competition_id: number;
+  title: string;
+  rank: number;
+  prize_description: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 interface ApiResponse<T> {
   message: string;
   data: T;
+}
+
+const CHAPTER_LOGOS: Record<number, string> = {
+  1: "/images/cs/CS-White.svg",
+  2: "/images/pes/PES-White.svg",
+  3: "/images/ras/RAS-White.svg",
+  4: "/images/wie/WIE-White.svg",
+};
+
+export function getChapterLogo(chapterId: number): string {
+  return CHAPTER_LOGOS[chapterId] || "/images/ieee/ieee-logo-white.svg";
 }
 
 export async function getCompetitions() {

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -7,6 +7,8 @@ export interface ApiEvent {
   description: string;
   overview?: string;
   image: string;
+  logo?: string | null;
+  cover_image?: string | null;
   link?: string;
   slug?: string;
 }

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   ApiSponsor
 } from "@/api/events";
 import api from "@/api";
+import Competitions from "@/components/ui/internal/events/mutex/competitions";
 
 export default function EventDetails() {
   const params = useParams();
@@ -183,11 +184,11 @@ export default function EventDetails() {
         </SectionContainer>
 
         {/* === COMPETITIONS SECTION === */}
-        <SectionContainer>
-          <SectionTitle title="Competitions" />
-          <SectionDescription description="Explore our diverse set of competitions." />
-          {/* Note: Mohamed Khaled will implement the competitions UI here */}
-        </SectionContainer>
+        <Competitions
+          eventSlug={eventData.slug || eventId}
+          eventId={eventData.id}
+          competitionsDescription="Explore our diverse set of competitions."
+        />
 
         {/* === SPEAKERS SECTION === */}
         <SectionContainer>

--- a/src/app/events/mutex/[id]/page.tsx
+++ b/src/app/events/mutex/[id]/page.tsx
@@ -1,196 +1,201 @@
-import { Metadata } from "next";
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import PageWrapper from "@/components/ui/internal/page-wrapper";
-import { eventsData } from "@/data/events";
-import { Box, Flex, Text } from "@chakra-ui/react";
-import HeroSection from "@/components/ui/internal/events/mutex/hero-section";
+import { Box, Flex, Text, Image } from "@chakra-ui/react";
+import { MoonLoader } from "react-spinners";
 import SectionTitle from "@/components/ui/internal/section-title";
 import SectionDescription from "@/components/ui/internal/section-description";
 import SectionContainer from "@/components/ui/internal/events/mutex/section-container";
-import NavButton from "@/components/ui/internal/nav-button";
 import AlternativeText from "@/components/ui/internal/alternative-text";
 import PrizesSection from "@/components/ui/internal/events/mutex/prizes-section";
+import NavButton from "@/components/ui/internal/nav-button";
+import {
+  getCompetitionById,
+  type ApiCompetition,
+} from "@/api/competitions";
+import { getEventById, type ApiEvent } from "@/api/events";
+import { useWindowType } from "@/hooks/use-window-type";
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}): Promise<Metadata> {
-  const { id } = await params;
+export default function CompetitionPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const { isMobile } = useWindowType();
 
-  const event = eventsData.find((event) =>
-    event.competitions.some(
-      (competition) => competition.shortName.toLowerCase() === id.toLowerCase()
-    )
-  );
+  const [competition, setCompetition] = useState<ApiCompetition | null>(null);
+  const [eventData, setEventData] = useState<ApiEvent | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const competition = event?.competitions.find(
-    (comp) => comp.shortName.toLowerCase() === id.toLowerCase()
-  );
+  useEffect(() => {
+    if (!id) return;
+    const competitionId = parseInt(id, 10);
+    if (isNaN(competitionId)) {
+      setError("Invalid competition ID");
+      setLoading(false);
+      return;
+    }
 
-  return {
-    title: competition?.name || "Competition Not Found",
-    description: competition?.description || "Details of the competition",
-  };
-}
+    let cancelled = false;
 
-export default async function CompetitionPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const { id } = await params;
+    getCompetitionById(competitionId)
+      .then((comp) => {
+        if (cancelled) return;
+        setCompetition(comp);
+        // Fetch event image separately — don't block the page if it fails
+        getEventById("mutex")
+          .then((ev) => { if (!cancelled) setEventData(ev); })
+          .catch((err) => console.warn("Failed to load event image:", err));
+      })
+      .catch(() => {
+        if (!cancelled) setError("Failed to load competition details.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
 
-  const event = eventsData.find((event) =>
-    event.competitions.some(
-      (competition) => competition.shortName.toLowerCase() === id.toLowerCase()
-    )
-  );
+    return () => { cancelled = true; };
+  }, [id]);
 
-  const competition = event?.competitions.find(
-    (comp) => comp.shortName.toLowerCase() === id.toLowerCase()
-  );
-
-  if (!event || !competition) {
-    return <div>Competition not found</div>;
+  if (loading) {
+    return (
+      <PageWrapper>
+        <Flex justify="center" align="center" h="50vh">
+          <MoonLoader size={50} color="#006699" />
+        </Flex>
+      </PageWrapper>
+    );
   }
 
-  const maxAmount = 20000;
+  if (error || !competition) {
+    return (
+      <PageWrapper>
+        <Flex justify="center" align="center" h="50vh">
+          <Text color="red.500" fontSize="xl">
+            {error || "Competition not found"}
+          </Text>
+        </Flex>
+      </PageWrapper>
+    );
+  }
+
+  // Use event cover_image/logo from backend, or fall back to local image
+  const eventImage =
+    eventData?.cover_image ||
+    eventData?.logo ||
+    `/events/mutex/mutex.webp`;
 
   return (
     <PageWrapper>
       <Flex
-        flexDirection={"column"}
+        flexDirection="column"
         alignItems="center"
         justifyContent="center"
         gap={20}
-        maxWidth={"1300px"}
-        mx={"auto"}
+        maxWidth="1300px"
+        mx="auto"
         mb={16}
       >
-        <HeroSection
-          title={competition.name}
-          description={competition.description}
-          imagePath={competition.image}
-          buttonLink={event.registerLink || event.link}
-          ruleBook={competition.rulebook}
-        />
-
-        <SectionContainer>
-          <SectionTitle title="Overview" />
-          <SectionDescription
-            description={competition.overview || "No description available"}
-          />
-        </SectionContainer>
-
-        <SectionContainer>
-          <SectionTitle title="Trophies" />
-          <SectionDescription description={competition.trophiesDescription} />
-          {competition.trophies && competition.trophies.length > 0 ? (
-            <Flex flexWrap="wrap" justify="center" align="end" gap={8} mt={10}>
-              {competition.trophies.map((trophy) => {
-                const amount = parseInt(trophy.amount.replace(/[^\d]/g, ""));
-                const height = (amount / maxAmount) * 400;
-
-                let bgColor;
-                if (trophy.place === "1st") bgColor = "primary-1";
-                else if (trophy.place === "2nd") bgColor = "primary-3";
-                else if (trophy.place === "3rd") bgColor = "primary-11";
-                else bgColor = "primary-10";
-
-                return (
-                  <Flex key={trophy.id} direction="column" align="center">
-                    <Text
-                      fontWeight="bold"
-                      color="neutral-1"
-                      fontSize={"2xl"}
-                      mb={2}
-                    >
-                      {trophy.amount}
-                    </Text>
-                    <Box
-                      width="170px"
-                      height={`${height}px`}
-                      rounded="xl"
-                      bg={bgColor}
-                      transition="height 0.3s ease"
-                    />
-                    <Text color="neutral-2" mt={2}>
-                      {trophy.place} place
-                    </Text>
-                  </Flex>
-                );
-              })}
+        {/* === HERO SECTION === */}
+        <Flex
+          flexWrap="wrap"
+          justifyContent="space-between"
+          alignItems="center"
+          flexDirection="row-reverse"
+          gap={6}
+          width="100%"
+        >
+          <Flex
+            bgColor="primary-5"
+            border="1px solid"
+            borderColor="primary-3"
+            rounded="2xl"
+            align="center"
+            justify="center"
+            overflow="hidden"
+            w={isMobile ? "full" : "444px"}
+            h="318px"
+            mx={isMobile ? "auto" : "0"}
+          >
+            <Image
+              src={eventImage}
+              alt={competition.name}
+              w="100%"
+              h="100%"
+              objectFit="cover"
+            />
+          </Flex>
+          <Flex
+            flexDir="column"
+            maxWidth="600px"
+            gap={4}
+            mx={isMobile ? "auto" : "0"}
+            justifyContent={isMobile ? "center" : "flex-start"}
+            alignItems={isMobile ? "center" : "flex-start"}
+          >
+            <Text fontSize="4xl" color="neutral-1" fontWeight="bold">
+              {competition.name}
+            </Text>
+            <Text color="neutral-2" whiteSpace="pre-line">
+              {competition.overview}
+            </Text>
+            <Flex gap={3} flexWrap="wrap">
+              <Box
+                bg="primary-5"
+                border="1px solid"
+                borderColor="primary-3"
+                rounded="full"
+                px={4}
+                py={1.5}
+              >
+                <Text color="primary-1" fontWeight="600" fontSize="sm">
+                  {competition.type === "team" ? "Team" : "Individual"}
+                </Text>
+              </Box>
+              {competition.type === "team" && competition.max_team_members > 0 && (
+                <Box
+                  bg="primary-5"
+                  border="1px solid"
+                  borderColor="primary-3"
+                  rounded="full"
+                  px={4}
+                  py={1.5}
+                >
+                  <Text color="primary-1" fontWeight="600" fontSize="sm">
+                    Up to {competition.max_team_members} members
+                  </Text>
+                </Box>
+              )}
             </Flex>
-          ) : (
-            <AlternativeText text="Stay tuned for our trophies announcements!" />
-          )}
-        </SectionContainer>
-
-        {competition.certificates && competition.certificates.length > 0 && (
-          <SectionContainer>
-            <SectionTitle title="Certificates" />
-            <SectionDescription description="Certificates will be awarded to the top three teams in each competition." />
-
-            <Flex direction="column" align="flex-start" gap={4} mt={10}>
-              {competition.certificates?.map((certificate, index) => {
-                const barWidths = [100, 150, 200];
-                const width = barWidths[index] || 150;
-
-                return (
-                  <Flex
-                    flexWrap="wrap"
-                    key={certificate.id}
-                    align="center"
-                    gap={4}
-                  >
-                    <Box
-                      width={`${width}px`}
-                      height="30px"
-                      bg="primary-1"
-                      rounded="md"
-                      transition="width 0.3s ease"
-                    />
-                    <Text
-                      fontWeight="bold"
-                      color="neutral-1"
-                      whiteSpace="nowrap"
-                    >
-                      {certificate.title}
-                    </Text>
-                  </Flex>
-                );
-              })}
+            <Flex gap={4} flexWrap="wrap">
+              <NavButton
+                link={`/events/mutex/registration`}
+                text="Register now!"
+              />
             </Flex>
-          </SectionContainer>
-        )}
+          </Flex>
+        </Flex>
 
+        {/* === PRIZES / TROPHIES SECTION (from API) === */}
         <PrizesSection
           competitionId={competition.id}
-          description={competition.trophiesDescription}
+          description={
+            competition.type === "team"
+              ? `Team competition (up to ${competition.max_team_members} members)`
+              : "Individual competition"
+          }
         />
 
-        {competition.rulebook && (
-          <SectionContainer>
-            <SectionTitle title="Rules" />
-            <SectionDescription description={competition.rulesDescription} />
-            <NavButton
-              link={competition.rulebook}
-              text="View Rule-book"
-              bgColor="primary-8"
-              color="neutral-5"
-            />
-          </SectionContainer>
-        )}
-
+        {/* === REGISTER CTA === */}
         <SectionContainer>
-          <SectionDescription
-            description={"What you're waiting? Register now!"}
+          <SectionDescription description="What are you waiting for? Register now!" />
+          <NavButton
+            link={`/events/mutex/registration`}
+            text="Register Now"
           />
-          <NavButton link={event.registerLink} text="Register Now" />
         </SectionContainer>
       </Flex>
     </PageWrapper>
   );
 }
-
-

--- a/src/app/events/mutex/page.tsx
+++ b/src/app/events/mutex/page.tsx
@@ -46,7 +46,12 @@ export default function Page() {
           />
         </SectionContainer>
 
-        {event && <Competitions event={event} />}
+        {event && (
+          <Competitions
+            eventSlug={event.slug || "mutex"}
+            competitionsDescription={event.competitionsDescription}
+          />
+        )}
 
         <SectionContainer>
           <SectionTitle title="Speakers" />

--- a/src/components/ui/internal/events/mutex/competition-card.tsx
+++ b/src/components/ui/internal/events/mutex/competition-card.tsx
@@ -1,44 +1,74 @@
 import React from "react";
-import type { Competition } from "@/data/events";
-import { Flex, Stack, Text } from "@chakra-ui/react";
-import NavButton from "@/components/ui/internal/nav-button";
-import ImageBox from "@/components/ui/internal/image-box";
+import Link from "next/link";
+import type { ApiCompetition } from "@/api/competitions";
+import { getChapterLogo } from "@/api/competitions";
+import { Box, Flex, Stack, Text, Image } from "@chakra-ui/react";
 
 export default function CompetitionCard({
   competition,
+  eventSlug,
 }: {
-  competition: Competition;
+  competition: ApiCompetition;
+  eventSlug: string;
 }) {
+  const chapterLogo = getChapterLogo(competition.chapter_id);
+  const detailLink = `/events/${eventSlug}/${competition.id}`;
+
   return (
-    <Flex flexDir="column" alignItems="center" gap={2} maxW="400px">
-      <Text color={"neutral-1"} fontSize={"2xl"} fontWeight={"bold"}>
+    <Flex flexDir="column" alignItems="center" gap={2} maxW="327px">
+      <Text color="neutral-1" fontSize="xl" fontWeight="bold">
         {competition.name}
       </Text>
-      <Flex w="full" h="full">
+      <Link href={detailLink} style={{ textDecoration: "none", width: "100%" }}>
         <Stack
           w="full"
           align="center"
           justify="space-between"
-          bgColor={"primary-5"}
+          bgColor="primary-5"
           border="1px solid"
           borderColor="primary-3"
-          padding={3}
-          rounded={"2xl"}
-          gap={2}
+          padding={4}
+          rounded="2xl"
+          gap={4}
+          minH="438px"
+          cursor="pointer"
+          _hover={{ borderColor: "primary-1" }}
+          transition="border-color 0.2s ease"
         >
-          <ImageBox
-            path={competition.image}
-            maxWidth="100%"
-            alt={competition.name}
-          />
-          <Text color={"neutral-2"}>{competition.description}</Text>
-          <NavButton
-            link={competition.link}
-            text="More about Competition"
-            width={"full"}
-          />
+          <Flex
+            align="center"
+            justify="center"
+            flex={1}
+            w="full"
+            py={6}
+          >
+            <Image
+              src={chapterLogo}
+              alt={competition.name}
+              maxW="200px"
+              maxH="200px"
+              objectFit="contain"
+            />
+          </Flex>
+          <Text color="neutral-2" fontSize="lg">
+            {competition.overview}
+          </Text>
+          <Box
+            as="span"
+            bg="primary-1"
+            color="white"
+            fontWeight="bold"
+            rounded="xl"
+            px={6}
+            py={3}
+            w="full"
+            textAlign="center"
+            fontSize="md"
+          >
+            Register now!
+          </Box>
         </Stack>
-      </Flex>
+      </Link>
     </Flex>
   );
 }

--- a/src/components/ui/internal/events/mutex/competitions.tsx
+++ b/src/components/ui/internal/events/mutex/competitions.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import type { Event } from "@/data/events";
 import SectionTitle from "@/components/ui/internal/section-title";
 import SectionDescription from "@/components/ui/internal/section-description";
 import { Flex, SimpleGrid, Spinner, Text } from "@chakra-ui/react";
@@ -9,21 +8,40 @@ import CompetitionCard from "@/components/ui/internal/events/mutex/competition-c
 import { useWindowType } from "@/hooks/use-window-type";
 import { getCompetitions, type ApiCompetition } from "@/api/competitions";
 
-export default function Competitions({ event }: { event: Event }) {
+export default function Competitions({
+  eventSlug,
+  eventId,
+  competitionsDescription,
+}: {
+  eventSlug: string;
+  eventId?: number | string;
+  competitionsDescription?: string;
+}) {
   const { isDesktop } = useWindowType();
   const [competitions, setCompetitions] = useState<ApiCompetition[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     getCompetitions()
-      .then(setCompetitions)
+      .then((data) => {
+        if (cancelled) return;
+        const filtered = eventId
+          ? data.filter((c) => String(c.event_id) === String(eventId))
+          : data;
+        setCompetitions(filtered);
+      })
       .catch((err) => {
+        if (cancelled) return;
         console.error("Failed to load competitions UI:", err);
         setError(true);
       })
-      .finally(() => setLoading(false));
-  }, []);
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [eventId]);
 
   return (
     <Flex
@@ -33,7 +51,9 @@ export default function Competitions({ event }: { event: Event }) {
       gap={4}
     >
       <SectionTitle title="Competitions" />
-      <SectionDescription description={event.competitionsDescription} />
+      <SectionDescription
+        description={competitionsDescription || "Explore our diverse set of competitions."}
+      />
 
       {loading ? (
         <Spinner color="primary-1" size="xl" />
@@ -43,7 +63,7 @@ export default function Competitions({ event }: { event: Event }) {
         <Text color="neutral-2">No competitions available yet.</Text>
       ) : (
         <SimpleGrid
-          columns={isDesktop ? 2 : 1}
+          columns={isDesktop ? 3 : 1}
           justifyContent="center"
           gap={8}
           p={4}
@@ -51,18 +71,8 @@ export default function Competitions({ event }: { event: Event }) {
           {competitions.map((competition) => (
             <CompetitionCard
               key={competition.id}
-              competition={{
-                id: competition.id,
-                name: competition.name,
-                shortName: competition.short_name,
-                image: competition.image,
-                description: competition.description,
-                link: `/events/${event.slug}/${competition.short_name}`,
-                overview: competition.overview,
-                trophiesDescription: competition.trophies_description,
-                rulesDescription: competition.rules_description,
-                rulebook: competition.rulebook ?? undefined,
-              }}
+              competition={competition}
+              eventSlug={eventSlug}
             />
           ))}
         </SimpleGrid>

--- a/src/components/ui/internal/events/mutex/prizes-section.tsx
+++ b/src/components/ui/internal/events/mutex/prizes-section.tsx
@@ -21,18 +21,39 @@ export default function PrizesSection({
 
   useEffect(() => {
     if (!competitionId) return;
+    let cancelled = false;
     getCompetitionPrizes(competitionId)
-      .then(setPrizes)
+      .then((data) => {
+        if (cancelled) return;
+        const sorted = [...data].sort((a, b) => a.rank - b.rank);
+        setPrizes(sorted);
+      })
       .catch((err) => {
+        if (cancelled) return;
         console.error("Failed to load prizes UI:", err);
         setError(true);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
   }, [competitionId]);
 
-  const maxAmount = prizes.length > 0
-    ? Math.max(...prizes.map((p) => parseFloat(p.amount.replace(/[^\d.]/g, "")) || 0))
-    : 1;
+  const maxRank = prizes.length > 0 ? Math.max(...prizes.map((p) => p.rank)) || 1 : 1;
+
+  const getRankColor = (rank: number) => {
+    if (rank === 1) return "primary-1";
+    if (rank === 2) return "primary-3";
+    if (rank === 3) return "primary-11";
+    return "primary-10";
+  };
+
+  const getRankLabel = (rank: number) => {
+    if (rank === 1) return "1st place";
+    if (rank === 2) return "2nd place";
+    if (rank === 3) return "3rd place";
+    return `${rank}th place`;
+  };
 
   return (
     <SectionContainer>
@@ -48,14 +69,9 @@ export default function PrizesSection({
       ) : (
         <Flex flexWrap="wrap" justify="center" align="end" gap={8} mt={10}>
           {prizes.map((prize) => {
-            const amount = parseFloat(prize.amount.replace(/[^\d.]/g, "")) || 0;
-            const height = maxAmount > 0 ? (amount / maxAmount) * 400 : 100;
-
-            let bgColor;
-            if (prize.place === "1st") bgColor = "primary-1";
-            else if (prize.place === "2nd") bgColor = "primary-3";
-            else if (prize.place === "3rd") bgColor = "primary-11";
-            else bgColor = "primary-10";
+            const height = maxRank > 0
+              ? ((maxRank - prize.rank + 1) / maxRank) * 400
+              : 100;
 
             return (
               <Flex key={prize.id} direction="column" align="center">
@@ -65,18 +81,23 @@ export default function PrizesSection({
                   fontSize="2xl"
                   mb={2}
                 >
-                  {prize.amount}
+                  {prize.title}
                 </Text>
                 <Box
                   width="170px"
                   height={`${height}px`}
                   rounded="xl"
-                  bg={bgColor}
+                  bg={getRankColor(prize.rank)}
                   transition="height 0.3s ease"
                 />
                 <Text color="neutral-2" mt={2}>
-                  {prize.place} place
+                  {getRankLabel(prize.rank)}
                 </Text>
+                {prize.prize_description && (
+                  <Text color="neutral-3" fontSize="sm" mt={1} textAlign="center" maxW="170px">
+                    {prize.prize_description}
+                  </Text>
+                )}
               </Flex>
             );
           })}


### PR DESCRIPTION
## What
Fetch the list of competitions and display their details. Implement fetching specific prizes related to each competition.

## Endpoints Used
- `GET /api/eventsgate/competitions` — list all competitions
- `GET /api/eventsgate/competitions/{id}` — get competition details
- `GET /api/eventsgate/competitions/{id}/prizes` — get competition prizes

## Changes

**API layer (`src/api/`)**
- Updated `ApiCompetition` and `ApiPrize` interfaces to match real backend response
- Added `getChapterLogo()` helper with chapter-to-logo mapping
- Added `logo`/`cover_image` fields to `ApiEvent` interface

**Competitions list (`competitions.tsx`)**
- Event-scoped filtering via `eventId` prop
- Added useEffect cleanup to prevent state updates after unmount

**Competition detail page (`events/mutex/[id]/page.tsx`)**
- Converted from static data to client component fetching from API
- Shows event image in hero with backend fallback chain
- Loading, error, and empty states

**Prizes section (`prizes-section.tsx`)**
- Updated to use new prize fields: `title`, `rank`, `prize_description`
- Division-by-zero guard for edge cases

**Event pages (`events/[id]/page.tsx`, `events/mutex/page.tsx`)**
- Wired `<Competitions>` component into event detail page
- Updated mutex landing page to pass new props
